### PR TITLE
Upgrade `DatabaseIdentifier` 🍓

### DIFF
--- a/Sources/Bridges/BridgesError.swift
+++ b/Sources/Bridges/BridgesError.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum BridgesError: Error {
     case failedToDecodeWithReturning
     case valueIsNilInKeyColumnUpdateIsImpossible
+    case nonGenericDatabaseIdentifier
 }

--- a/Sources/Bridges/DatabaseIdentifier.swift
+++ b/Sources/Bridges/DatabaseIdentifier.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct DatabaseIdentifier {
+open class DatabaseIdentifier {
     public let name: String?
     public let host: DatabaseHost
     public let maxConnectionsPerEventLoop: Int

--- a/Sources/Bridges/Protocols/AnyBridgesObject.swift
+++ b/Sources/Bridges/Protocols/AnyBridgesObject.swift
@@ -1,0 +1,15 @@
+//
+//  AnyBridgesObject.swift
+//  Bridges
+//
+//  Created by Mihael Isaev on 09.05.2020.
+//
+
+import Logging
+import NIO
+
+public protocol AnyBridgesObject {
+    var logger: Logger { get }
+    var bridges: Bridges { get }
+    var eventLoop: EventLoop { get }
+}

--- a/Sources/Bridges/Protocols/AnyDatabaseIdentifiable.swift
+++ b/Sources/Bridges/Protocols/AnyDatabaseIdentifiable.swift
@@ -1,0 +1,19 @@
+//
+//  AnyDatabaseIdentifiable.swift
+//  Bridges
+//
+//  Created by Mihael Isaev on 09.05.2020.
+//
+
+import SwifQL
+import NIO
+
+public protocol AnyDatabaseIdentifiable {}
+public protocol AnyMySQLDatabaseIdentifiable: AnyDatabaseIdentifiable {}
+public protocol AnyPostgresDatabaseIdentifiable: AnyDatabaseIdentifiable {}
+
+public protocol DatabaseIdentifiable {
+    associatedtype B: Bridgeable
+}
+public protocol MySQLDatabaseIdentifiable: DatabaseIdentifiable, AnyMySQLDatabaseIdentifiable {}
+public protocol PostgresDatabaseIdentifiable: DatabaseIdentifiable, AnyPostgresDatabaseIdentifiable {}

--- a/Sources/Bridges/Protocols/BridgesApplication.swift
+++ b/Sources/Bridges/Protocols/BridgesApplication.swift
@@ -8,8 +8,13 @@
 import Foundation
 import Logging
 
-public protocol BridgesApplication {
+public protocol BridgesApplication: AnyBridgesObject {
     var logger: Logger { get }
     var bridges: Bridges { get }
     var eventLoopGroup: EventLoopGroup { get }
+}
+
+/// See: `AnyBridgesObject`
+extension BridgesApplication {
+    public var eventLoop: EventLoop { eventLoopGroup.next() }
 }

--- a/Sources/Bridges/Protocols/BridgesRequest.swift
+++ b/Sources/Bridges/Protocols/BridgesRequest.swift
@@ -5,7 +5,16 @@
 //  Created by Mihael Isaev on 30.01.2020.
 //
 
-public protocol BridgesRequest {
+import Logging
+import NIO
+
+public protocol BridgesRequest: AnyBridgesObject {
     var bridgesApplication: BridgesApplication { get }
     var eventLoop: EventLoop { get }
+}
+
+/// See: `AnyBridgesObject`
+extension BridgesRequest {
+    public var logger: Logger { bridgesApplication.logger }
+    public var bridges: Bridges { bridgesApplication.bridges }
 }

--- a/Sources/Bridges/Protocols/ContextBridgeable.swift
+++ b/Sources/Bridges/Protocols/ContextBridgeable.swift
@@ -1,0 +1,12 @@
+//
+//  ContextBridgeable.swift
+//  Bridges
+//
+//  Created by Mihael Isaev on 09.05.2020.
+//
+
+public protocol ContextBridgeable {
+    associatedtype B: Bridgeable
+    
+    var context: BridgeWithContext<B> { get }
+}


### PR DESCRIPTION
I've pimped `DatabaseIdentifier` to use it for conveniences which will be available in next PR.

It is not breaking change, but if someone is using custom `DatabaseIdentifier` in case if he will try to use new conveniences it will throw an error and print a message in console that he should use explicit initialization for identifier.

So e.g. this
```swift
extension DatabaseIdentifier {
    static var dev_mysql: DatabaseIdentifier {
        .init(name: "dev_test", host: DatabaseHost(hostname: "127.0.0.1", port: 3306, username: "root", password: "qwerty"), maxConnectionsPerEventLoop: 1)
    }
}
```
should be replaced with
```swift
extension DatabaseIdentifier {
    static var dev_mysql: DatabaseIdentifier {
        .mysql(name: "dev_test", host: DatabaseHost(hostname: "127.0.0.1", port: 3306, username: "root", password: "qwerty"), maxConnectionsPerEventLoop: 1)
    }
}
```